### PR TITLE
Replace 'SubfieldBase' with 'from_db_value()'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   - DJANGO_VERSION=1.5
   - DJANGO_VERSION=1.6
   - DJANGO_VERSION=1.7
+  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION=1.9
 install:
   - pip install -q Django==$DJANGO_VERSION --use-mirrors
   - pip install -q -r requirements.txt --use-mirrors

--- a/encrypted_fields/fields.py
+++ b/encrypted_fields/fields.py
@@ -45,8 +45,8 @@ class EncryptedFieldMixin(object):
     data in your database. This lives in a Keyczar key directory specified by:
     the setting - settings.ENCRYPTED_FIELDS_KEYDIR -
 
-    Optionally, you can name specific encryption keys for data-specific purposes
-    in your model such as:
+    Optionally, you can name specific encryption keys for data-specific
+    purposes in your model such as:
         special_data = EncrytpedCharField( ..., keyname='special_data' )
 
     The Mixin will handle the encryption/decryption seamlessly, but native
@@ -77,7 +77,6 @@ class EncryptedFieldMixin(object):
     A ValueError will be raised if the encrypted length of the data (including
     prefix if specified) is greater than the max_length of the field.
     """
-    __metaclass__ = models.SubfieldBase
 
     def __init__(self, *args, **kwargs):
         """
@@ -137,7 +136,11 @@ class EncryptedFieldMixin(object):
 
         # Ensure the encrypted data does not exceed the max_length
         # of the database. Data truncation is a possibility otherwise.
-        self.enforce_max_length = getattr(settings, 'ENFORCE_MAX_LENGTH', False)
+        self.enforce_max_length = getattr(
+            settings,
+            'ENFORCE_MAX_LENGTH',
+            False
+        )
         if not self.enforce_max_length:
             self.enforce_max_length = kwargs.pop('enforce_max_length', False)
 
@@ -148,6 +151,9 @@ class EncryptedFieldMixin(object):
 
     def get_internal_type(self):
         return 'TextField'
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
 
     def to_python(self, value):
         if value is None or not isinstance(value, types.StringTypes):
@@ -186,10 +192,9 @@ class EncryptedFieldMixin(object):
 
             if self.enforce_max_length:
                 if (
-                    value
-                    and hasattr(self, 'max_length')
-                    and self.max_length
-                    and len(value) > self.max_length
+                    value and hasattr(self, 'max_length') and
+                    self.max_length and
+                    len(value) > self.max_length
                 ):
                     raise ValueError(
                         'Field {0} max_length={1} encrypted_len={2}'.format(
@@ -218,8 +223,8 @@ class EncryptedIntegerField(EncryptedFieldMixin, models.IntegerField):
     def validators(self):
         """
         See issue https://github.com/defrex/django-encrypted-fields/issues/7
-        Need to keep all field validators, but need to change `get_internal_type` on the fly
-        to prevent fail in django 1.7.
+        Need to keep all field validators, but need to change
+        `get_internal_type` on the fly to prevent fail in django 1.7.
         """
         self.get_internal_type = lambda: 'IntegerField'
         return models.IntegerField.validators.__get__(self)

--- a/encrypted_fields/fields.py
+++ b/encrypted_fields/fields.py
@@ -2,6 +2,7 @@
 import os
 import types
 
+import django
 from django.db import models
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -77,6 +78,9 @@ class EncryptedFieldMixin(object):
     A ValueError will be raised if the encrypted length of the data (including
     prefix if specified) is greater than the max_length of the field.
     """
+
+    if django.VERSION < (1, 8):
+        __metaclass__ = models.SubfieldBase
 
     def __init__(self, *args, **kwargs):
         """

--- a/encrypted_fields/tests.py
+++ b/encrypted_fields/tests.py
@@ -39,8 +39,16 @@ class TestCrypter(object):
 
 class TestModel(models.Model):
     char = EncryptedCharField(max_length=255, null=True, blank=True)
-    prefix_char = EncryptedCharField(max_length=255, prefix='ENCRYPTED:::', blank=True)
-    decrypt_only = EncryptedCharField(max_length=255, decrypt_only=True, blank=True)
+    prefix_char = EncryptedCharField(
+        max_length=255,
+        prefix='ENCRYPTED:::',
+        blank=True
+    )
+    decrypt_only = EncryptedCharField(
+        max_length=255,
+        decrypt_only=True,
+        blank=True
+    )
     short_char = EncryptedCharField(
         max_length=50, null=True, enforce_max_length=True, blank=True)
 
@@ -53,11 +61,16 @@ class TestModel(models.Model):
     boolean = EncryptedBooleanField(default=False, blank=True)
 
     char_custom_crypter = EncryptedCharField(
-        max_length=255, null=True,crypter_klass=TestCrypter, blank=True)
+        max_length=255,
+        null=True,
+        crypter_klass=TestCrypter,
+        blank=True
+    )
 
 
 class FieldTest(TestCase):
-    IS_POSTGRES = settings.DATABASES['default']['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+    IS_POSTGRES = settings.DATABASES['default']['ENGINE'] == \
+        'django.db.backends.postgresql_psycopg2'
 
     def get_db_value(self, field, model_id):
         cursor = connection.cursor()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django>=1.4
-python-keyczar==0.71c
+python-keyczar==0.715

--- a/testsettings.py
+++ b/testsettings.py
@@ -14,4 +14,6 @@ INSTALLED_APPS = (
     'encrypted_fields',
 )
 
+MIDDLEWARE_CLASSES = []
+
 ENCRYPTED_FIELDS_KEYDIR = os.path.join(os.path.dirname(__file__), 'testkey')


### PR DESCRIPTION
_SubfieldBase_ is deprecated as of Django 1.8 and will be removed in Django 1.10. This pull request simply removes the EncryptedFieldMixin _metaclass_ variable and its _SubfieldBase_ value, and adds _from_db_value()_.

Since we don't need to do anything with our field values beyond decrypting them, _from_db_value()_ simply calls _to_python()_ to decrypt the data and return the proper Python object.

Other, minor updates:
* The Travis CI config includes Django 1.8 and 1.9
* python-keyczar is now set to 0.715 in requirements.txt, the latest version as of this commit
* Line breaks for PEP8 compliance