### PR TITLE
Resolve #25: binascii.Error: Incorrect Padding

### DIFF
--- a/encrypted_fields/fields.py
+++ b/encrypted_fields/fields.py
@@ -176,6 +176,8 @@ class EncryptedFieldMixin(object):
             pass
         except UnicodeEncodeError:
             pass
+        except binascii.Error:
+            pass        
 
         return super(EncryptedFieldMixin, self).to_python(value)
 


### PR DESCRIPTION
Per https://github.com/defrex/django-encrypted-fields/issues/25, this resolves binascii.Error: Incorrect Padding on certain inputs to encrypted fields.