### PR TITLE
Use correct params for from_db_value()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9
   - DJANGO_VERSION=1.10
+  - DJANGO_VERSION=1.11
 install:
   - pip install -q Django==$DJANGO_VERSION
   - pip install -q -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ python:
   - "2.7"
   - "3.5"
 env:
-  - DJANGO_VERSION=1.4
-  - DJANGO_VERSION=1.5
-  - DJANGO_VERSION=1.6
   - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "2.7"
   - "3.5"
 env:
-  - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9
   - DJANGO_VERSION=1.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
 env:
   - DJANGO_VERSION=1.4
   - DJANGO_VERSION=1.5

--- a/encrypted_fields/__init__.py
+++ b/encrypted_fields/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.1.2'
+__version__ = '1.2.0a1'
 
 from .fields import *

--- a/encrypted_fields/fields.py
+++ b/encrypted_fields/fields.py
@@ -5,7 +5,6 @@ import django
 from django.db import models
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 
@@ -159,7 +158,7 @@ class EncryptedFieldMixin(object):
         return self.to_python(value)
 
     def to_python(self, value):
-        if value is None or not isinstance(value, six.string_types):
+        if value is None or not isinstance(value, (str, bytes)):
             return value
 
         if self.prefix and value.startswith(self.prefix):

--- a/encrypted_fields/fields.py
+++ b/encrypted_fields/fields.py
@@ -159,7 +159,7 @@ class EncryptedFieldMixin(object):
     def load_crypter(self):
         self._crypter = self._crypter_klass(self.keydir)
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection, **kwargs):
         return self.to_python(value)
 
     def to_python(self, value):

--- a/encrypted_fields/fields.py
+++ b/encrypted_fields/fields.py
@@ -1,12 +1,14 @@
 
 import os
 import types
+import binascii
 
 import django
 from django.db import models
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
+from django.utils import six
 
 try:
     from django.utils.encoding import smart_text
@@ -163,7 +165,7 @@ class EncryptedFieldMixin(object):
         return self.to_python(value)
 
     def to_python(self, value):
-        if value is None or not isinstance(value, types.StringTypes):
+        if value is None or not isinstance(value, six.string_types):
             return value
 
         if self.prefix and value.startswith(self.prefix):
@@ -177,7 +179,7 @@ class EncryptedFieldMixin(object):
         except UnicodeEncodeError:
             pass
         except binascii.Error:
-            pass        
+            pass
 
         return super(EncryptedFieldMixin, self).to_python(value)
 
@@ -187,7 +189,7 @@ class EncryptedFieldMixin(object):
         if value is None or value == '' or self.decrypt_only:
             return value
 
-        if isinstance(value, types.StringTypes):
+        if isinstance(value, six.string_types):
             value = value.encode('unicode_escape')
             value = value.encode('ascii')
         else:

--- a/encrypted_fields/tests.py
+++ b/encrypted_fields/tests.py
@@ -120,7 +120,7 @@ class FieldTest(TestCase):
         model.save()
 
         plaintext = self.get_db_value('decrypt_only', model.id)
-        self.assertEquals(plaintext, known_plaintext)
+        self.assertEqual(plaintext, known_plaintext)
 
     def test_decrypt_only_plaintext(self):
         known_plaintext = 'I am so plain and ordinary'
@@ -129,7 +129,7 @@ class FieldTest(TestCase):
         model.save()
 
         plaintext = self.get_db_value('decrypt_only', model.id)
-        self.assertEquals(plaintext, known_plaintext)
+        self.assertEqual(plaintext, known_plaintext)
 
     def test_char_field_encrypted(self):
         plaintext = 'Oh hi, test reader!'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django>=1.8
-python-keyczar==0.716
+python3-keyczar==0.71rc0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.4
-python-keyczar==0.715
+Django>=1.8
+python-keyczar==0.716

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     version=version,
     install_requires=[
         'Django>=1.4',
-        'python-keyczar>=0.71c',
+        'python3-keyczar>=0.71c',
     ],
 )


### PR DESCRIPTION
from_db_value() "context" param generates a deprecation warning in Django 2.2 - should be **kwargs